### PR TITLE
Add Claude Code link under coding agents section

### DIFF
--- a/content/links/machine-learning-and-artificial-intelligence/index.md
+++ b/content/links/machine-learning-and-artificial-intelligence/index.md
@@ -17,6 +17,9 @@ hideAsideBar = true
 ### general
 - [TheFocus/AI Distill the signal from the noise](https://thefocus.ai/)
 
+### coding agents
+- [Claude Code](https://claude.com/product/claude-code)
+
 ### on automation
 
 - [Ironies of Automation](https://www.complexcognition.co.uk/2021/06/ironies-of-automation.html)


### PR DESCRIPTION
Added a new 'coding agents' section to the Machine Learning and Artificial Intelligence links page with a link to Claude Code.

Closes #2

Generated with [Claude Code](https://claude.ai/code)