### PR TITLE
Update copyright year to 2026

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -10,7 +10,7 @@ theme = 'ryder-dev'
 timeZone = "America/Los_Angeles"
 title = "Ben Strawbridge Dot Com Consulting"
 description = 'My place to work on my online projects and experiment with the web.'
-copyright = '<i class="fa-regular fa-copyright"></i>  2024 benstrawbridge.com'
+copyright = '<i class="fa-regular fa-copyright"></i>  2026 benstrawbridge.com'
 [params]
   description = 'Dot Com Consulting'
   TocOpen = true


### PR DESCRIPTION
Updates the copyright year from 2024 to 2026 in the Hugo configuration.

Closes #5

Generated with [Claude Code](https://claude.ai/code)