### PR TITLE
Add Sequoia Capital product health link

### DIFF
--- a/content/links/the-web/index.md
+++ b/content/links/the-web/index.md
@@ -21,5 +21,6 @@ hideAsideBar = true
 - [Steve Francia workshop slides "Product Management for everyone"](https://spf13.com/presentation/product-management-for-everyone/)
 - [Steve Yegge Portrait of n00b](https://steve-yegge.blogspot.com/2008/02/portrait-of-n00b.html?m=1)
 - [OSInt and privacy Experts](https://inteltechniques.com/index.html)
+- [How Sequoia Capital measures product health](https://articles.sequoiacap.com/measuring-product-health)
 
 <!--more-->


### PR DESCRIPTION
Added the link "How Sequoia Capital measures product health" to The Web section of the links page.

Closes #7

Generated with [Claude Code](https://claude.ai/code)