### PR TITLE
Move link to top and document ordering convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ hugo new content projects/recipes/my-recipe.md
 hugo new content --kind recipe projects/recipes/recipe-name.md
 ```
 
+**Link ordering convention**: When adding new links to any section (e.g., `/links/the-web/`), always add them to the **top** of the list, not the bottom. This keeps the most recent additions visible first.
+
 ### Theme & Submodules
 ```bash
 # Initialize theme submodule (first-time setup)

--- a/content/links/the-web/index.md
+++ b/content/links/the-web/index.md
@@ -14,6 +14,7 @@ hideAsideBar = true
 # showTOC = true
 +++
 
+- [How Sequoia Capital measures product health](https://articles.sequoiacap.com/measuring-product-health)
 - [What screens want](https://frankchimero.com/blog/2013/what-screens-want/)
 - [The webs grain](https://frankchimero.com/blog/2015/the-webs-grain/)
 - [the 12 factors](https://12factor.net/). To build solid web applications start with the fundamentals
@@ -21,6 +22,5 @@ hideAsideBar = true
 - [Steve Francia workshop slides "Product Management for everyone"](https://spf13.com/presentation/product-management-for-everyone/)
 - [Steve Yegge Portrait of n00b](https://steve-yegge.blogspot.com/2008/02/portrait-of-n00b.html?m=1)
 - [OSInt and privacy Experts](https://inteltechniques.com/index.html)
-- [How Sequoia Capital measures product health](https://articles.sequoiacap.com/measuring-product-health)
 
 <!--more-->


### PR DESCRIPTION
Moved the Sequoia Capital link to the top of The Web section and added documentation to CLAUDE.md about the link ordering convention.

Closes #7

Generated with [Claude Code](https://claude.ai/code)