### PR TITLE
Remove weight parameter from content to fix homepage ordering

### DIFF
--- a/content/projects/recipes/moms-family-recipes-cookbook/lemon-mint/index.md
+++ b/content/projects/recipes/moms-family-recipes-cookbook/lemon-mint/index.md
@@ -6,7 +6,6 @@ hideAsideBar = true
 homeFeatureIcon = "fa-brands fa-pagelines"
 categories = ['recipes']
 tags = ["family recipes"]
-weight = 10
 
 recipe = true
 recipeCuisine = "Beverage"

--- a/content/projects/recipes/moms-family-recipes-cookbook/mashies/index.md
+++ b/content/projects/recipes/moms-family-recipes-cookbook/mashies/index.md
@@ -5,7 +5,6 @@ date = 2024-05-06T14:43:16-07:00
 hideAsideBar = true
 categories = ['recipes']
 tags = ["family recipes"]
-weight = 50
 
 recipe = true
 recipeCuisine = "Side"

--- a/content/projects/the-ryder-theme-for-hugo/index.md
+++ b/content/projects/the-ryder-theme-for-hugo/index.md
@@ -9,7 +9,6 @@ tags = [
   "Open Source",
   "Web Development"
 ]
-weight = 20
 featured_image = "ryder-theme-og.jpg"
 # homeFeature = true
 homeFeatureIcon = "fa-solid fa-dog"


### PR DESCRIPTION
Fixes #21

Removes the `weight` parameter from three content items that were incorrectly appearing at the top of the latest content section.

In Hugo, pages with weight values are sorted before pages without weight, which caused these items to always appear first regardless of their publish dates.

**Changed files:**
- Aunt Mary's LemonMint
- The Ryder Theme for Hugo
- Mashies

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/benstraw/benstrawbridge.com/tree/claude/issue-21-20260130-0457