### PR TITLE
Update links section dates to match git history

### DIFF
--- a/content/links/analytics/index.md
+++ b/content/links/analytics/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Analytics'
-date = 2024-11-08T11:37:45-08:00
+date = 2024-11-08T12:05:31-08:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/art/index.md
+++ b/content/links/art/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Art'
-date = 2024-11-08T11:35:58-08:00
+date = 2024-12-09T14:54:08-08:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/blogroll/index.md
+++ b/content/links/blogroll/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Blogroll'
-date = 2024-11-08T11:36:42-08:00
+date = 2024-11-08T12:05:31-08:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/crypto/index.md
+++ b/content/links/crypto/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Crypto'
-date = 2024-11-08T11:40:27-08:00
+date = 2024-11-08T12:05:31-08:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/css/index.md
+++ b/content/links/css/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Css'
-date = 2024-11-08T11:40:11-08:00
+date = 2024-11-08T12:05:31-08:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/email/index.md
+++ b/content/links/email/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Email'
-date = 2024-11-08T11:47:29-08:00
+date = 2024-11-08T12:05:31-08:00
 draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/fonts-icons/index.md
+++ b/content/links/fonts-icons/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Fonts & Icons'
-date = 2024-11-08T11:41:12-08:00
+date = 2024-11-08T12:05:31-08:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/hugo/index.md
+++ b/content/links/hugo/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Hugo'
-date = 2024-11-08T11:41:27-08:00
+date = 2024-11-08T12:05:31-08:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/machine-learning-and-artificial-intelligence/index.md
+++ b/content/links/machine-learning-and-artificial-intelligence/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Machine Learning and Artificial Intelligence'
-date = 2024-11-08T11:38:36-08:00
+date = 2026-01-28T20:29:32-08:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/mapping/index.md
+++ b/content/links/mapping/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Mapping'
-date = 2024-11-08T11:38:06-08:00
+date = 2024-11-08T12:05:31-08:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/oblargh/index.md
+++ b/content/links/oblargh/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Oblargh'
-date = 2024-11-08T10:48:23-08:00
+date = 2026-01-27T05:58:18+00:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/services/index.md
+++ b/content/links/services/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Services'
-date = 2024-11-08T11:46:34-08:00
+date = 2024-11-08T12:05:31-08:00
 draft = true
 # I like this by default now... keeps the page full width with tags below.
 # hideAsideBar = true

--- a/content/links/testing/index.md
+++ b/content/links/testing/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Testing'
-date = 2024-11-08T11:39:07-08:00
+date = 2024-11-08T12:05:31-08:00
 draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/the-web/index.md
+++ b/content/links/the-web/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'The Web'
-date = 2024-11-08T11:39:53-08:00
+date = 2026-01-13T22:38:49+00:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true

--- a/content/links/tools/index.md
+++ b/content/links/tools/index.md
@@ -1,6 +1,6 @@
 +++
 title = 'Tools'
-date = 2024-11-08T11:39:30-08:00
+date = 2024-12-09T14:54:08-08:00
 # draft = true
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true


### PR DESCRIPTION
### Summary

Updated all 15 links sections with accurate `date` fields matching their last content-changing commits. This fixes the homepage feed ordering issue where Hugo was appearing before more recently updated sections like Oblargh and Machine Learning.

### Changes

- Updated `date` fields in 15 links section pages to reflect last content changes
- Excluded global reorganization commits (weight removal, graveyard reorg)
- Verified all other content pages have proper dates

### Recent Updates
- Machine Learning: 2026-01-28 (Add Gas Town and Beads links)
- Oblargh: 2026-01-27 (Add Dangerous Roads link)
- The Web: 2026-01-13 (Move Sequoia Capital link to top)
- Art & Tools: 2024-12-09 (small updates)

### Impact

Ensures correct homepage feed sorting by providing accurate fallback dates when git timestamps are identical or when `enableGitInfo` fails in production.

Closes #23

---

Generated with [Claude Code](https://claude.ai/code)