### PR TITLE
Add Aperture Lightning Network link to crypto section

### DIFF
--- a/content/links/crypto/index.md
+++ b/content/links/crypto/index.md
@@ -14,6 +14,7 @@ hideAsideBar = true
 # showTOC = true
 +++
 
+- [Aperture - Lightning Network Authentication & Paid APIs](https://docs.lightning.engineering/lightning-network-tools/aperture/get-aperture)
 - [the arkham computer](https://platform.arkhamintelligence.com/)
 - [advanced charting](https://beta.bitcoinwisdom.io/)
 <!--more-->


### PR DESCRIPTION
Added link to Aperture documentation at the top of the crypto links section following the repository convention.

Fixes #28

Generated with [Claude Code](https://claude.ai/code)