### PR TITLE
Add mushroom hallucination link to Oblargh section

### DIFF
--- a/content/links/oblargh/index.md
+++ b/content/links/oblargh/index.md
@@ -13,6 +13,7 @@ hideAsideBar = true
 # homeFeatureIcon = ""
 # showTOC = true
 +++
+- [Mushroom causes fairytale-like hallucinations](https://attheu.utah.edu/science-technology/mushroom-causes-fairytale-like-hallucinations/)
 - [Dangerous Roads](https://www.dangerousroads.org/)
 - [What can't everyone have a dog?](https://www.whispered.com/career/prepare-search/Company-stages)
 


### PR DESCRIPTION
Added link about fairytale-like hallucinations caused by mushrooms to the Oblargh section per repo convention (new links at top of list).

Resolves #31

Generated with [Claude Code](https://claude.ai/code)