### PR TITLE
Move OCR search post to projects and create blog announcement

### DIFF
--- a/content/posts/gordon-landreth-photography-site/index.md
+++ b/content/posts/gordon-landreth-photography-site/index.md
@@ -1,0 +1,11 @@
++++
+title = 'Gordon Landreth Photography Gallery'
+date = 2026-02-10T00:00:00-08:00
+tags = ["photography", "family-history", "hugo", "static-site"]
++++
+
+I've launched [Gordon Landreth Photography](https://gordon-landreth-photography.arts-link.com/), a digital gallery showcasing my grandfather's photography from 1931 through the 1990s. The site contains 48 photo albums with over 3,400 scanned pages.
+
+The most useful feature is the [search interface](https://gordon-landreth-photography.arts-link.com/search/) that lets you find photos by searching the typed captions on each album page. Search for names, places, dates, or events and get instant results with thumbnail previews. No backend required - everything runs client-side using OCR-extracted text and fuzzy matching.
+
+For those interested in the technical implementation, I wrote up a [detailed project writeup](/projects/ocr-powered-search-photo-gallery/) covering the OCR pipeline, search architecture, vision models, and UX decisions.

--- a/content/projects/ocr-powered-search-photo-gallery/index.md
+++ b/content/projects/ocr-powered-search-photo-gallery/index.md
@@ -57,7 +57,7 @@ I wanted family members to search for names ("Show me all photos of Louise"), pl
 
 **Privacy & Copyright:** These are family photos, not public domain. The site uses `noindex, nofollow` robots tags and privacy-focused Plausible analytics.
 
-**OCR Quality:** These are 1940s-1980s photos with typed captions. Quality varies from crisp typewriter text to faded, skewed, or low-contrast text. Perfect transcription wasn't realistic—I needed "searchable enough."
+**OCR Quality:** These are 1940s-1980s photos with typed captions. Quality varies from crisp typewriter text to faded, skewed, or low-contrast text. Perfect transcription wasn't realistic. I needed "searchable enough."
 
 ### Architecture Decision: Client-Side Search
 
@@ -146,7 +146,7 @@ Line breaks indicate natural reading flow and continuation. The structured `capt
 
 ### Development Workflow: Fast Rebuilds
 
-Processing 3,416 images takes time. My **separate index rebuild script** (`rebuild_search_index.py`) reads existing OCR JSONs and regenerates the search index in 3-5 seconds—invaluable for testing search functionality and fixing metadata bugs without rerunning OCR.
+Processing 3,416 images takes time. My **separate index rebuild script** (`rebuild_search_index.py`) reads existing OCR JSONs and regenerates the search index in 3-5 seconds. This is invaluable for testing search functionality and fixing metadata bugs without rerunning OCR.
 
 ### Vision Model for Final Production
 
@@ -213,7 +213,7 @@ Initial search results showed album title, page filename, and caption text. Func
 
 ### PhotoSwipe Integration
 
-The gallery already used PhotoSwipe for album pages. Reusing it for search results meant consistent UX with full keyboard navigation, swipe gestures, and caption display—no new dependencies.
+The gallery already used PhotoSwipe for album pages. Reusing it for search results meant consistent UX with full keyboard navigation, swipe gestures, and caption display. No new dependencies.
 
 **Implementation challenge:** PhotoSwipe needs image dimensions, but search results don't include them. I dynamically load dimensions when building the PhotoSwipe data source.
 
@@ -223,7 +223,7 @@ Now clicking a thumbnail opens a full-screen lightbox where you can browse searc
 
 ### Grouped Search Results
 
-When searching for an album name, both the album and individual pages appeared in results—confusing. I split results into two groups:
+When searching for an album name, both the album and individual pages appeared in results. This was confusing. I split results into two groups:
 
 1. **Album Title Matches** - The album name itself matched
 2. **Caption Matches** - The OCR caption text matched
@@ -254,7 +254,7 @@ I used [LM Studio](https://lmstudio.ai/) to run **MiniCPM-V 2.6** vision model l
 2. Search for "MiniCPM-V 2.6" and download (~8GB)
 3. Start server (defaults to `http://localhost:1234`)
 
-Within 10 minutes, I had a local vision model server. No API keys, no cloud services, full privacy—just a simple HTTP endpoint.
+Within 10 minutes, I had a local vision model server. No API keys, no cloud services, full privacy. Just a simple HTTP endpoint.
 
 ### Implementation
 
@@ -338,7 +338,7 @@ I used **Tesseract during development** for fast iteration and testing, then re-
 
 **Add Thumbnails Earlier:** Visual previews should have been in the initial design.
 
-**Test with Real Use Cases:** I tested with hypothetical queries. Real use revealed I needed grouping, thumbnails, and lightbox—not better query parsing.
+**Test with Real Use Cases:** I tested with hypothetical queries. Real use revealed I needed grouping, thumbnails, and lightbox, not better query parsing.
 
 **Trust Simplicity:** I planned complex features I never needed. Fuzzy matching + good UX won.
 
@@ -381,7 +381,7 @@ Building search for 3,400+ scanned photo album pages taught me that "good enough
 
 The system shipped with features I didn't plan (PhotoSwipe lightbox, thumbnails, grouped results) and without features I thought essential (Boolean AND, phrase search). Real use revealed what mattered.
 
-Family members are now finding photos they forgot existed. Click a thumbnail, browse results in full-screen lightbox, navigate with arrow keys, see high-quality captions from the vision model. Search isn't just functional—it's delightful.
+Family members are now finding photos they forgot existed. Click a thumbnail, browse results in full-screen lightbox, navigate with arrow keys, see high-quality captions from the vision model.
 
 ---
 


### PR DESCRIPTION
- Moved OCR-powered search technical writeup from /posts to /projects
- Removed all em dashes from the technical post
- Removed AI-sounding language like 'Search isn't just functional—it's delightful'
- Created new blog post announcing Gordon Landreth Photography site
- Blog post links to both the live site and the detailed technical writeup

Closes #39

Generated with [Claude Code](https://claude.ai/code)