### PR TITLE
Remove tarragon beets salad and hugo deploy post from homepage

### DIFF
--- a/content/posts/hugo-deploy-script/index.md
+++ b/content/posts/hugo-deploy-script/index.md
@@ -5,7 +5,6 @@ date = 2024-09-14T23:40:27-07:00
 # I like this by default now... keeps the page full width with tags below.
 hideAsideBar = true
 # homeFeatureWide = true
-homeFeature = true
 homeFeatureIcon = "fa-solid fa-code-merge"
 # summary = ""
 # # categories = [""]

--- a/content/projects/recipes/tarragon-beets-salad/index.md
+++ b/content/projects/recipes/tarragon-beets-salad/index.md
@@ -2,7 +2,6 @@
 title = 'Tarragon Beets Salad'
 date = 2023-08-04T11:56:15-08:00
 # draft = true
-homeFeature = true
 tags = [
   "healthy",
   "vegan",


### PR DESCRIPTION
Removed `homeFeature=true` from both content files to exclude them from the homepage feature list.

Closes #41

Generated with [Claude Code](https://claude.ai/code)