### PR TITLE
Add Mozilla State of the Internet link

### DIFF
--- a/content/links/the-web/index.md
+++ b/content/links/the-web/index.md
@@ -14,6 +14,7 @@ hideAsideBar = true
 # showTOC = true
 +++
 
+- [Mozilla State of the Internet](https://stateof.mozilla.org/)
 - [How Sequoia Capital measures product health](https://articles.sequoiacap.com/measuring-product-health)
 - [What screens want](https://frankchimero.com/blog/2013/what-screens-want/)
 - [The webs grain](https://frankchimero.com/blog/2015/the-webs-grain/)


### PR DESCRIPTION
Adds https://stateof.mozilla.org/ to The Web section.

Resolves #45

Generated with [Claude Code](https://claude.ai/code)