### PR TITLE
links: add The Onion InfoWars takeover link

### DIFF
--- a/content/links/theonion-info.md
+++ b/content/links/theonion-info.md
@@ -1,0 +1,8 @@
++++
+title = "The Onion InfoWars"
+date = 2026-04-25T08:35:00-07:00
+draft = false
+link_url = "https://theonion.info/"
+description = "The Onion's satirical takeover of InfoWars."
+tags = ["oblargh", "satire", "humor"]
++++


### PR DESCRIPTION
Adds https://theonion.info/ to the links archive with oblargh, satire, and humor tags.

Closes #80

Generated with [Claude Code](https://claude.ai/code)