### PR TITLE
fix: weekly listening pages missing from home feed

### DIFF
--- a/content/listening/artists/_content.gotmpl
+++ b/content/listening/artists/_content.gotmpl
@@ -1,3 +1,5 @@
+{{/* TODO: artist pages have no "dates" key set, so they sort to the bottom of the home feed.
+     Fix: derive date from $artist.last_seen and pass "dates" (dict "date" $date) in $page. */}}
 {{ $artists := site.Data.spotify.artists }}
 
 {{ range $slug, $artist := $artists }}

--- a/content/listening/weekly/_content.gotmpl
+++ b/content/listening/weekly/_content.gotmpl
@@ -16,7 +16,7 @@
       "topArtistName" $week.topArtistName
     }}
     {{ $page := dict
-      "content" (dict "mediaType" "text/markdown" "value" "")
+      "content" (dict "mediaType" "text/markdown" "value" (printf "%d plays · Top artist: %s" ($week.total_plays | int) $week.topArtistName))
       "title" $week.title
       "type" "listening-weekly"
       "params" $params


### PR DESCRIPTION
The weekly content adapter was setting an empty content value, which
caused every generated weekly page to have an empty .Summary. The home
feed template skips pages with no link_url and empty summary, so all
weekly pages were silently excluded.

Sets the content value to a short stats string (plays · top artist) so
the summary is non-empty and weekly pages appear in the feed, sorted
by date_start which was already wired correctly.

Also adds a TODO in the artists content adapter about adding dates from
last_seen so artist pages sort meaningfully in the feed.

https://claude.ai/code/session_01Vkb8JpVXHXDx9GVbCRRe9a