### PR TITLE
Point two relrefs at the pages they moved to

### DIFF
--- a/content/projects/hiking/westchester-playa-vista-playa-del-rey-hiking-guide/oberrieder-dog-park/index.md
+++ b/content/projects/hiking/westchester-playa-vista-playa-del-rey-hiking-guide/oberrieder-dog-park/index.md
@@ -19,6 +19,6 @@ lon = "-118.42061"
 
 {{< leaflet id="oberrieder" lat="33.97186" lon="-118.42061" zoom="17.5" divHeight="350px" >}}
 
-Oberrieder Dog Park is a large, partially shaded woodchip covered enclosure for dogs and humans to relax and enjoy the company of other dogs (and humans). It is next to a beautiful walking path along the oberreider wetlands with views of the bluffs under LMU. This path easily connects to the [Bluff Creek Trail]({{< relref "/projects/hiking/westchester-playa-vista-playa-del-rey-hiking-guide/bluff-creek-trail" >}}) for the back half of a 4.5 mile loop.
+Oberrieder Dog Park is a large, partially shaded woodchip covered enclosure for dogs and humans to relax and enjoy the company of other dogs (and humans). It is next to a beautiful walking path along the oberreider wetlands with views of the bluffs under LMU. This path easily connects to the [Bluff Creek Trail]({{< relref "/trails/bluff-creek-trail" >}}) for the back half of a 4.5 mile loop.
 
 <!--more-->

--- a/content/projects/this-website/index.md
+++ b/content/projects/this-website/index.md
@@ -12,7 +12,7 @@ I also try to publish brief how-to guides when I find myself stumped and have on
 
 <!--more-->
 
-One of the ongoing projects I am working on here is figuring out optimal, minimalist ways to integrate content marketing techniques such as affiliate links into the project. You will see some links spread throughout the site. [Read the full disclosure statement]({{< relref "/amazon-affiliate-disclosure" >}}).
+One of the ongoing projects I am working on here is figuring out optimal, minimalist ways to integrate content marketing techniques such as affiliate links into the project. You will see some links spread throughout the site. [Read the full disclosure statement]({{< relref "/fineprint/amazon-affiliate-disclosure" >}}).
 
 ## Screenshot history
 


### PR DESCRIPTION
Two `relref`s pointed at paths their target pages had moved away from. Both rendered `href=""`, so clicking either one reloaded the current page.

`refLinksErrorLevel = "WARNING"`, so the build emitted the empty link instead of failing — silent in CI, broken in the browser.

### `oberrieder-dog-park` → Bluff Creek Trail

Referenced the trail under the hiking guide. It now lives at `/trails/bluff-creek-trail`, and the move left an alias behind at the old URL.

The alias is what made this easy to miss: **`relref` resolves against content paths, not aliases.** An alias only generates a redirect page at build time, so the old path stayed a working URL for anyone typing it while being unresolvable as a ref.

⚠️ The guide also contains a separate `bluff-trail` page titled "Bluff Trail". The link text and the alias both confirm the intended target is the moved page, not the sibling.

### `this-website` → Amazon affiliate disclosure

Referenced `/amazon-affiliate-disclosure` at the site root; the page is published at `/fineprint/amazon-affiliate-disclosure`.

This one surfaced **only in a build with `-D`**, because `this-website` is `draft = true` — which is why it never appeared in the production log alongside the other.

### Verification

Swept with and without drafts:

| build | `REF_NOT_FOUND` |
|---|---|
| `--environment production` | **0** |
| `-D --environment development` | **0** |

Both links now resolve — `/trails/bluff-creek-trail/` and `/fineprint/amazon-affiliate-disclosure/`.

`refLinksErrorLevel` deliberately left at `WARNING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
