### PR TITLE
Fix affiliate link builder CSP violation and missing associate ID

### DIFF
--- a/assets/js/extended.js
+++ b/assets/js/extended.js
@@ -164,6 +164,55 @@ if (window.Alpine && window.Alpine !== Alpine) {
   registerLinksPage(window.Alpine)
 }
 
+// CSP-safe replacement for the theme's `affiliateLinkBuilder` component, used
+// by layouts/shortcodes/affiliate-link-builder-form.html (a site override of
+// the theme shortcode) on /link-builder/.
+//
+// The theme's version returns the result as an HTML string and the theme
+// shortcode renders it with x-html. @alpinejs/csp refuses that directive
+// outright — "Using the x-html directive is prohibited in the CSP build" —
+// so #affiliate-link stayed permanently empty: no placeholder, no generated
+// link, a Generate Link button that visibly did nothing. (Other components on
+// the page still initialised; the thrown error is scoped to this directive.)
+//
+// So the anchor is markup in the template and this component only exposes
+// plain values for it to bind to. Registered under a different name because
+// main.js registers `affiliateLinkBuilder` after this file runs (ES imports
+// are hoisted, so extended.js executes first) and would overwrite it.
+const registerAmazonLinkBuilder = (alpine) => alpine.data('amazonLinkBuilder', () => ({
+  asin: '',
+  affiliateTag: '',
+  generated: false,
+  init() {
+    this.affiliateTag = this.$el.dataset.defaultTag || ''
+  },
+  isValidAsin(asin) {
+    return /^[A-Z0-9]{10}$/.test(asin)
+  },
+  // Only complain once there is something to complain about — an untouched
+  // field is not an error.
+  showAsinError() {
+    return this.asin.length > 0 && !this.isValidAsin(this.asin)
+  },
+  validateAsin() {
+    this.asin = this.asin.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 10)
+    this.generated = false
+  },
+  generateAffiliateLink() {
+    if (!this.isValidAsin(this.asin)) return
+    this.generated = true
+  },
+  get affiliateUrl() {
+    return `https://www.amazon.com/dp/${encodeURIComponent(this.asin)}` +
+      `/ref=nosim?tag=${encodeURIComponent(this.affiliateTag)}`
+  },
+}))
+
+registerAmazonLinkBuilder(Alpine)
+if (window.Alpine && window.Alpine !== Alpine) {
+  registerAmazonLinkBuilder(window.Alpine)
+}
+
 // Check if the changeBackgroundImage function exists before calling it
 if (typeof changeBackgroundImage === "function") {
   changeBackgroundImage([

--- a/config/production/hugo.toml
+++ b/config/production/hugo.toml
@@ -14,7 +14,24 @@ enableGitInfo = false
   analytics_provider = "posthog"
   posthog_host = "https://t.benstrawbridge.com"
   posthog_ui_host = "https://us.posthog.com"
-  posthog_cookie_domain = ".benstrawbridge.com"
+
+  # Deliberately no posthog_cookie_domain. The theme partial forwards it as
+  # `cookie_domain` in posthog.init(), but posthog-js has no such option —
+  # verified against 1.414.0, where the string appears nowhere in lib/ or any
+  # dist/ bundle. It was silently dropped, so the value here only ever looked
+  # like it pinned the cookie domain.
+  #
+  # What actually governs the domain is `cross_subdomain_cookie`, which
+  # defaults to on and makes posthog-js discover the domain by probing. That
+  # probe walks inward from the TLD, so its first attempt is always
+  # `domain=.com` — a public suffix — and the browser logs
+  #   Cookie "dmn_chk_<uuidv7>" has been rejected for invalid domain.
+  # once per page load before the next attempt (.benstrawbridge.com) sticks.
+  # That console line is expected and costs nothing; cookies work. Turning it
+  # off means overriding layouts/partials/posthog.html to pass
+  # cross_subdomain_cookie = false, which scopes cookies to www alone and
+  # breaks identity continuity across any future subdomain. Not worth it.
+
   posthog_defaults = "2026-01-30"
   posthog_person_profiles = "identified_only"
 

--- a/layouts/shortcodes/affiliate-link-builder-form.html
+++ b/layouts/shortcodes/affiliate-link-builder-form.html
@@ -1,0 +1,72 @@
+{{- /* Site override of themes/ryder/layouts/shortcodes/affiliate-link-builder-form.html.
+
+  Two things differ from the theme version, both of which broke /link-builder/:
+
+  1. The theme renders the generated link with
+       x-html="affiliateLink || 'Enter an ASIN…'"
+     and the theme bundles @alpinejs/csp, which refuses x-html outright:
+       Uncaught Error: Using the x-html directive is prohibited in the CSP build
+     The result div therefore never rendered anything at all — not even the
+     "Enter an ASIN…" placeholder — so Generate Link looked dead. Here the
+     anchor is real markup bound with :href / x-text, and the component
+     (amazonLinkBuilder, in assets/js/extended.js) hands over plain values.
+
+  2. The theme reads site.Params.amazonAffiliateTags, which this site does not
+     set — it has amazon_associate_id, the param every other affiliate
+     template here uses. The result was data-default-tag="" and links built as
+     ?tag=, i.e. no associate credit at all. Fall back to it.
+
+  Keep this in sync with the theme shortcode if it changes upstream; the fix
+  belongs there eventually. */ -}}
+
+{{- $tags := slice -}}
+{{- with site.Params.amazonAffiliateTags -}}
+  {{- $tags = . -}}
+{{- else -}}
+  {{- with site.Params.amazon_associate_id -}}
+    {{- $tags = slice . -}}
+  {{- end -}}
+{{- end -}}
+{{- $defaultTag := "" -}}
+{{- if gt (len $tags) 0 -}}
+  {{- $defaultTag = index $tags 0 -}}
+{{- else -}}
+  {{- warnf "affiliate-link-builder-form (%s): neither params.amazonAffiliateTags nor params.amazon_associate_id is set, so generated links will carry no affiliate tag." .Page.File.Path -}}
+{{- end -}}
+
+<div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 w-full" x-data="amazonLinkBuilder" data-default-tag="{{ $defaultTag }}">
+  <form>
+    <div class="-mx-3 mb-6">
+      <div class="w-full px-3">
+        <label class="block uppercase tracking-wide text-gray-700 font-bold mb-2" for="asin"> ASIN </label>
+        <input class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="asin" type="text" placeholder="Enter ASIN" x-model="asin" :class="{'border-red-500': showAsinError()}" @input="validateAsin">
+        <p class="text-red-500 text-xs italic" x-show="showAsinError()">Please enter a valid ASIN.</p>
+      </div>
+    </div>
+    {{- if gt (len $tags) 1 }}
+    <div class="-mx-3 mb-6">
+      <div class="w-full px-3">
+        <label class="block uppercase tracking-wide text-gray-700 font-bold mb-2" for="affiliate-tag"> Affiliate Tag </label>
+        <select class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="affiliate-tag" x-model="affiliateTag">
+          {{- range $tags }}
+          <option value="{{ . }}">{{ . }}</option>
+          {{- end }}
+        </select>
+      </div>
+    </div>
+    {{- end }}
+    <div class="-mx-3 mb-6">
+      <div class="w-full px-3">
+        <button aria-label="Generate Link" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" type="button" @click="generateAffiliateLink" :disabled="!isValidAsin(asin)">
+          Generate Link
+        </button>
+      </div>
+    </div>
+  </form>
+  <div class="text-gray-700" id="affiliate-link" aria-live="polite">
+    <span x-show="!generated">Enter an ASIN and click Generate Link to get started</span>
+    <span x-show="generated">View ASIN
+      <a class="bg-yellow-400 text-black font-medium py-2 mt-4 px-4 rounded-full border-2 border-yellow-500 hover:bg-yellow-500 hover:border-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-300 no-underline inline-block text-center break-words" :href="affiliateUrl" x-text="asin"></a>
+      on Amazon.com</span>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
Fixes the broken `/link-builder/` page by replacing the theme's CSP-incompatible `x-html` directive with proper markup binding and adding fallback support for the site's `amazon_associate_id` parameter.

## Changes

### Layout Override: `layouts/shortcodes/affiliate-link-builder-form.html`
- Created site override of the theme's affiliate link builder shortcode
- **CSP fix**: Replaced `x-html` directive (prohibited in `@alpinejs/csp`) with real anchor markup bound via `:href` and `x-text`
- **Parameter fallback**: Added logic to check `params.amazonAffiliateTags` first, then fall back to `params.amazon_associate_id` (the parameter this site actually uses)
- Includes detailed comments explaining both issues and their solutions

### Component: `assets/js/extended.js`
- Added new `amazonLinkBuilder` Alpine component to replace the theme's `affiliateLinkBuilder`
- Registered under a different name to avoid being overwritten by the theme's version loaded in `main.js`
- Exposes plain values (`asin`, `affiliateUrl`, `generated`) for template binding instead of returning HTML strings
- Implements ASIN validation (10 alphanumeric characters), auto-uppercasing, and error display
- Generates properly formatted Amazon affiliate URLs with the selected tag

### Configuration: `config/production/hugo.toml`
- Removed `posthog_cookie_domain` parameter with detailed explanation
- Added comprehensive comment documenting why this parameter is ineffective: `posthog-js` doesn't recognize it, and the actual domain behavior is controlled by `cross_subdomain_cookie` (which defaults to enabled and works correctly despite expected console warnings)

## Implementation Details
- The component validates ASINs only after user input begins (no error on empty field)
- Auto-formats ASIN input: converts to uppercase, strips non-alphanumeric characters, limits to 10 characters
- Affiliate URL construction uses `encodeURIComponent` for proper URL encoding
- Both Alpine instances (main and CSP-safe) register the component to handle different build scenarios

https://claude.ai/code/session_01AAkx8XYfdhfeNAtaoSmcXk